### PR TITLE
vuln: bump crypto to 41.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ msrestazure==0.4.34
 adal==1.2.4
 pyopenssl==23.2.0
 kubernetes==12.0.1
-cryptography==41.0.0
+cryptography==41.0.2


### PR DESCRIPTION
also forces a rebuild to get rid of the certifi vulnerability