### PR TITLE
crypto 42.0.3 to 42.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ wheel>=0.38.1
 azure-keyvault==1.0.0
 msrestazure==0.4.34
 adal==1.2.4
-cryptography==42.0.3
+cryptography==42.0.4


### PR DESCRIPTION
crypto 42.0.3 to 42.0.4 version bump for a new vulnerability found in temporary test clusters:

https://github.com/advisories/GHSA-6vqw-3v5j-54x4