### PR TITLE
[keyvault-agent] Add kubernetes code with cryptography to handle secrets

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,12 +31,11 @@ import logging
 import base64
 import requests
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization import pkcs12
 from adal import AuthenticationContext
 from azure.keyvault import KeyVaultClient
+from cryptography.hazmat.primitives import serialization
 from msrestazure.azure_active_directory import AdalAuthentication, MSIAuthentication
+from kubernetes import client, config
 
 logging.basicConfig(level=logging.INFO,
                     format='|%(asctime)s|%(levelname)-5s|%(process)d|%(thread)d|%(name)s|%(message)s')
@@ -165,6 +164,131 @@ class KeyVaultAgent(object):
             _logger.error('Exception occured while trying to auto detect AAD tenant. Using the config default %s', tenant_id_from_config)
         return tenant_id_from_config
 
+    def _get_kubernetes_api_instance(self):
+        if self._api_instance is None:
+            config.load_incluster_config()
+            client.configuration.assert_hostname = False
+            self._api_instance = client.CoreV1Api()
+
+        return self._api_instance
+
+    def _get_kubernetes_secrets_list(self):
+        if self._secrets_list is None:
+            api_instance = self._get_kubernetes_api_instance()
+            api_response = api_instance.list_namespaced_secret(namespace=self._secrets_namespace)
+
+            secret_name_list = []
+            should_continue = True
+
+            while should_continue is True:
+                continue_value = api_response.metadata._continue
+                secrets_list = api_response.items
+                for item in secrets_list:
+                    secret_name_list.append(item.metadata.name)
+
+                if continue_value is not None:
+                    api_response = api_instance.list_namespaced_secret(namespace=self._secrets_namespace, _continue = continue_value)
+                else:
+                    should_continue = False
+
+            self._secrets_list = secret_name_list
+
+        return self._secrets_list
+
+    def _create_kubernetes_secret_objects(self, key, secret_value, secret_type):
+        key = key.lower()
+        api_instance = self._get_kubernetes_api_instance()
+        secret = client.V1Secret()
+
+        secret.metadata = client.V1ObjectMeta(name=key)
+        secret.type = secret_type
+
+        if secret.type == 'kubernetes.io/tls':
+            _logger.info('Extracting private key and certificate.')
+            # Use cryptography to deserialize a PKCS12. Get the private key and certificates.
+            # Note we don't need to pass any backend argument, as it is not required
+            # and its use has been deprecated already.
+            (privateKey, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
+                base64.b64decode(secret_value),
+                None
+            )
+            ca_certs = ()
+            if os.getenv('DOWNLOAD_CA_CERTIFICATES','true').lower() == "true":
+                ca_certs = (tuple(additional_certificates) or ())
+                certs = (certificate,) + ca_certs
+            else:
+                certs = (certificate,)
+            privateKey = privateKey.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption()
+            )
+            certString = ""
+            for cert in certs:
+                certString += cert.public_bytes(encoding=serialization.Encoding.PEM).decode()
+            secret.data = { 'tls.crt' : base64.b64encode(certString.encode()).decode(), 'tls.key' : base64.b64encode(privateKey).decode() }
+            if ca_certs:
+                ca_certs_string = ""
+                for cert in ca_certs:
+                    ca_certs_string += cert.public_bytes(encoding=serialization.Encoding.PEM).decode()
+                secret.data.update({'ca.crt': base64.b64encode(ca_certs_string.encode()).decode()})
+
+        else:
+            secretDataKey = key.upper() + "_SECRETS_DATA_KEY"
+            secret_data_key = os.getenv(secretDataKey, 'secret')
+            secret.data = { secret_data_key : base64.b64encode(secret_value.encode()).decode() }
+
+        secrets_list = self._get_kubernetes_secrets_list()
+
+        _logger.info('Creating or updating Kubernetes Secret object: %s', key)
+        try:
+            if key in secrets_list:
+                api_instance.patch_namespaced_secret(name=key, namespace=self._secrets_namespace, body=secret)
+            else:
+                api_instance.create_namespaced_secret(namespace=self._secrets_namespace, body=secret)
+        except:
+            _logger.exception("Failed to create or update Kubernetes Secret")
+
+    def grab_secrets_kubernetes_objects(self):
+        """
+        Gets secrets from KeyVault and creates them as Kubernetes secrets objects
+        """
+        vault_base_url = os.getenv('VAULT_BASE_URL')
+        secrets_keys = os.getenv('SECRETS_KEYS')
+        self._secrets_namespace = os.getenv('SECRETS_NAMESPACE','default')
+
+        client = self._get_client()
+        _logger.info('Using vault: %s', vault_base_url)
+
+        # Retrieving all secrets from Key Vault if specified by user
+        if secrets_keys is None:
+            _logger.info('Retrieving all secrets from Key Vault.')
+
+            all_secrets = list(client.get_secrets(vault_base_url))
+            secrets_keys = ';'.join([secret.id.split('/')[-1] for secret in all_secrets])
+
+        if secrets_keys is not None:
+            for key_info in filter(None, secrets_keys.split(';')):
+                key_name, key_version, cert_filename, key_filename = self._split_keyinfo(key_info)
+                _logger.info('Retrieving secret name:%s with version: %s output certFileName: %s keyFileName: %s', key_name, key_version, cert_filename, key_filename)
+                secret = client.get_secret(vault_base_url, key_name, key_version)
+
+                secretTypeEnvKey = key_name.upper() + "_SECRET_TYPE"
+                secret_type = os.getenv(secretTypeEnvKey, os.getenv("SECRETS_TYPE", 'Opaque'))
+                if secret_type == 'kubernetes.io/tls':
+                    if secret.kid is not None:
+                        _logger.info('Secret is backing certificate.')
+                        if secret.content_type == 'application/x-pkcs12':
+                            self._create_kubernetes_secret_objects(key_name, secret.value, secret_type)
+                        else:
+                            _logger.error('Secret is not in pkcs12 format')
+                            sys.exit(1)
+                    elif (key_name != cert_filename):
+                        _logger.error('Cert filename provided for secret %s not backing a certificate.', key_name)
+                        sys.exit(('Error: Cert filename provided for secret {0} not backing a certificate.').format(key_name))
+                else:
+                    self._create_kubernetes_secret_objects(key_name, secret.value, secret_type)
+
     def grab_secrets(self):
         """
         Gets secrets from KeyVault and stores them in a folder
@@ -229,10 +353,12 @@ class KeyVaultAgent(object):
                     cert_file.write(self._cert_to_pem(cert.cer))
 
     def _dump_pfx(self, pfx, cert_filename, key_filename):
-        pk, certificate, additional_certificates = pkcs12.load_key_and_certificates(
+        # Use cryptography to deserialize a PKCS12. Get the private key and certificates.
+        # Note we don't need to pass any backend argument, as it is not required
+        # and its use has been deprecated already.
+        (pk, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
             base64.b64decode(pfx),
-            None,
-            default_backend()
+            None
         )
         if os.getenv('DOWNLOAD_CA_CERTIFICATES','true').lower() == "true":
             certs = (certificate,) + (tuple(additional_certificates) or ())
@@ -297,5 +423,8 @@ class KeyVaultAgent(object):
 
 if __name__ == '__main__':
     _logger.info('Grabbing secrets from Key Vault')
-    KeyVaultAgent().grab_secrets()
+    if os.getenv('CREATE_KUBERNETES_SECRETS','false').lower() == "true":
+        KeyVaultAgent().grab_secrets_kubernetes_objects()
+    else:
+        KeyVaultAgent().grab_secrets()
     _logger.info('Done!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-pip>=23.3
-setuptools>=65.5.1
-wheel>=0.38.1
-azure-keyvault==1.0.0
-msrestazure==0.4.34
 adal==1.2.4
+azure-keyvault==1.0.0
 cryptography==42.0.4
+kubernetes==12.0.1
+msrestazure==0.4.34
+requests==2.31.0


### PR DESCRIPTION
This PR reverts the deletion of the kubernetes code to handle secrets and adapts code to use the `cryptography` package to handle the PKCS12.

Also, explicitly adds `requests` package since it is no longer installed indirectly by others packages.