### PR TITLE
vuln: bump requests from 2.31.0 to 2.32.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ azure-keyvault==1.0.0
 cryptography==42.0.4
 kubernetes==12.0.1
 msrestazure==0.4.34
-requests==2.31.0
+requests==2.32.2


### PR DESCRIPTION
https://portal.microsofticm.com/imp/v5/incidents/details/506789593/summary

https://github.com/advisories/GHSA-9wx4-h78v-vm56

I'm told 2.32.0 has an issue, so I updated to 2.32.2. There was a potential compatibility/deprecation issue that isn't relevant to this code:
https://github.com/psf/requests/releases/tag/v2.32.2