### PR TITLE
Fix pkcs12 bug

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ import requests
 from adal import AuthenticationContext
 from azure.keyvault import KeyVaultClient
 from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.serialization import pkcs12
 from msrestazure.azure_active_directory import AdalAuthentication, MSIAuthentication
 from kubernetes import client, config
 
@@ -208,7 +209,8 @@ class KeyVaultAgent(object):
             # Use cryptography to deserialize a PKCS12. Get the private key and certificates.
             # Note we don't need to pass any backend argument, as it is not required
             # and its use has been deprecated already.
-            (privateKey, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
+            # (privateKey, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
+            (privateKey, certificate, additional_certificates) = pkcs12.load_key_and_certificates(
                 base64.b64decode(secret_value),
                 None
             )
@@ -356,7 +358,8 @@ class KeyVaultAgent(object):
         # Use cryptography to deserialize a PKCS12. Get the private key and certificates.
         # Note we don't need to pass any backend argument, as it is not required
         # and its use has been deprecated already.
-        (pk, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
+        # (pk, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
+        (pk, certificate, additional_certificates) = pkcs12.load_key_and_certificates(
             base64.b64decode(pfx),
             None
         )

--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,7 @@ import requests
 from adal import AuthenticationContext
 from azure.keyvault import KeyVaultClient
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.hazmat.primitives.serialization import pkcs12 # we need to explicitly import this
 from msrestazure.azure_active_directory import AdalAuthentication, MSIAuthentication
 from kubernetes import client, config
 
@@ -209,7 +209,6 @@ class KeyVaultAgent(object):
             # Use cryptography to deserialize a PKCS12. Get the private key and certificates.
             # Note we don't need to pass any backend argument, as it is not required
             # and its use has been deprecated already.
-            # (privateKey, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
             (privateKey, certificate, additional_certificates) = pkcs12.load_key_and_certificates(
                 base64.b64decode(secret_value),
                 None
@@ -358,7 +357,6 @@ class KeyVaultAgent(object):
         # Use cryptography to deserialize a PKCS12. Get the private key and certificates.
         # Note we don't need to pass any backend argument, as it is not required
         # and its use has been deprecated already.
-        # (pk, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
         (pk, certificate, additional_certificates) = pkcs12.load_key_and_certificates(
             base64.b64decode(pfx),
             None
@@ -425,7 +423,6 @@ class KeyVaultAgent(object):
 
 
 if __name__ == '__main__':
-    _logger.info('TODO: remove this - just making sure we are running the right code') # TODO: remove this
     _logger.info('Grabbing secrets from Key Vault')
     if os.getenv('CREATE_KUBERNETES_SECRETS','false').lower() == "true":
         KeyVaultAgent().grab_secrets_kubernetes_objects()

--- a/app/main.py
+++ b/app/main.py
@@ -425,6 +425,7 @@ class KeyVaultAgent(object):
 
 
 if __name__ == '__main__':
+    _logger.info('TODO: remove this - just making sure we are running the right code') # TODO: remove this
     _logger.info('Grabbing secrets from Key Vault')
     if os.getenv('CREATE_KUBERNETES_SECRETS','false').lower() == "true":
         KeyVaultAgent().grab_secrets_kubernetes_objects()


### PR DESCRIPTION
This PR fixes the pkcs12 issue (see details in logs) in cryptography 43.0.1 after the version bump
Turns out that we need to explicitly import the `pkcs12` module even though that wasn't necessary before.

What I was getting:

```
17:27:08 [1] $ kubectl logs -n skyman azsecpack-deployment-hp6d8 -c keyvault-agent
|2024-09-09 17:25:15,229|INFO |1|136742683851648|keyvault-agent|Grabbing secrets from Key Vault
|2024-09-09 17:25:15,229|INFO |1|136742683851648|keyvault-agent|Parsing Service Principle file from: /host-sp/azure.json
|2024-09-09 17:25:15,229|INFO |1|136742683851648|keyvault-agent|AAD tenant auto detection turned off. Using tenant id 72f988bf-86f1-41af-91ab-2d7cd011db47 from cloud config
|2024-09-09 17:25:15,229|INFO |1|136742683851648|keyvault-agent|Parsing Service Principle file completed
|2024-09-09 17:25:15,229|INFO |1|136742683851648|keyvault-agent|Using MSI
|2024-09-09 17:25:15,229|INFO |1|136742683851648|keyvault-agent|Using client_id: 39a3c423-9b21-4f43-97d9-9042af96a786
|2024-09-09 17:25:15,265|INFO |1|136742683851648|keyvault-agent|Using vault: https://SpSvcCertificatesDev.vault.azure.net
|2024-09-09 17:25:15,265|INFO |1|136742683851648|keyvault-agent|Retrieving secret name:publisher-geneva-keyvault-speech-microsoft-com with version:  output certFileName: publisher-geneva-keyvault-speech-microsoft-com keyFileName: publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 17:25:15,734|INFO |1|136742683851648|keyvault-agent|Secret is backing certificate. Dumping private key and certificate.
Traceback (most recent call last):
  File "/acs-keyvault-agent/app/main.py", line 429, in <module>
    KeyVaultAgent().grab_secrets()
  File "/acs-keyvault-agent/app/main.py", line 330, in grab_secrets
    self._dump_pfx(secret.value, cert_filename, key_filename)
  File "/acs-keyvault-agent/app/main.py", line 359, in _dump_pfx
    (pk, certificate, additional_certificates) = serialization.pkcs12.load_key_and_certificates(
AttributeError: module 'cryptography.hazmat.primitives.serialization' has no attribute 'pkcs12'
```

Expected output:


```
18:11:44 [0] $ kubectl logs -n skyman azsecpack-deployment-h72vv -c keyvault-agent
|2024-09-09 02:30:14,567|INFO |1|127217114381184|keyvault-agent|Grabbing secrets from Key Vault
|2024-09-09 02:30:14,567|INFO |1|127217114381184|keyvault-agent|Parsing Service Principle file from: /host-sp/azure.json
|2024-09-09 02:30:14,568|INFO |1|127217114381184|keyvault-agent|AAD tenant auto detection turned off. Using tenant id 72f988bf-86f1-41af-91ab-2d7cd011db47 from cloud config
|2024-09-09 02:30:14,568|INFO |1|127217114381184|keyvault-agent|Parsing Service Principle file completed
|2024-09-09 02:30:14,568|INFO |1|127217114381184|keyvault-agent|Using MSI
|2024-09-09 02:30:14,568|INFO |1|127217114381184|keyvault-agent|Using client_id: 39a3c423-9b21-4f43-97d9-9042af96a786
|2024-09-09 02:30:14,593|INFO |1|127217114381184|keyvault-agent|Using vault: https://SpSvcCertificatesDev.vault.azure.net
|2024-09-09 02:30:14,593|INFO |1|127217114381184|keyvault-agent|Retrieving secret name:publisher-geneva-keyvault-speech-microsoft-com with version:  output certFileName: publisher-geneva-keyvault-speech-microsoft-com keyFileName: publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 02:30:15,054|INFO |1|127217114381184|keyvault-agent|Secret is backing certificate. Dumping private key and certificate.
|2024-09-09 02:30:15,105|INFO |1|127217114381184|keyvault-agent|Dumping key value to: /secrets/keys/publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 02:30:15,106|INFO |1|127217114381184|keyvault-agent|Dumping certs to: /secrets/certs/publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 02:30:15,106|INFO |1|127217114381184|keyvault-agent|Dumping secret value to: /secrets/secrets/publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 02:30:15,106|INFO |1|127217114381184|keyvault-agent|Done!
```

What I was able to get in my last test:

```
18:30:32 [0] $ kubectl logs -n skyman azsecpack-deployment-ghgm9 -c keyvault-agent
|2024-09-09 18:30:20,514|INFO |1|129545540610944|keyvault-agent|Grabbing secrets from Key Vault
|2024-09-09 18:30:20,515|INFO |1|129545540610944|keyvault-agent|Parsing Service Principle file from: /host-sp/azure.json
|2024-09-09 18:30:20,515|INFO |1|129545540610944|keyvault-agent|AAD tenant auto detection turned off. Using tenant id 72f988bf-86f1-41af-91ab-2d7cd011db47 from cloud config
|2024-09-09 18:30:20,515|INFO |1|129545540610944|keyvault-agent|Parsing Service Principle file completed
|2024-09-09 18:30:20,515|INFO |1|129545540610944|keyvault-agent|Using MSI
|2024-09-09 18:30:20,515|INFO |1|129545540610944|keyvault-agent|Using client_id: 39a3c423-9b21-4f43-97d9-9042af96a786
|2024-09-09 18:30:20,545|INFO |1|129545540610944|keyvault-agent|Using vault: https://SpSvcCertificatesDev.vault.azure.net
|2024-09-09 18:30:20,545|INFO |1|129545540610944|keyvault-agent|Retrieving secret name:publisher-geneva-keyvault-speech-microsoft-com with version:  output certFileName: publisher-geneva-keyvault-speech-microsoft-com keyFileName: publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 18:30:20,999|INFO |1|129545540610944|keyvault-agent|Secret is backing certificate. Dumping private key and certificate.
|2024-09-09 18:30:21,068|INFO |1|129545540610944|keyvault-agent|Dumping key value to: /secrets/keys/publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 18:30:21,069|INFO |1|129545540610944|keyvault-agent|Dumping certs to: /secrets/certs/publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 18:30:21,069|INFO |1|129545540610944|keyvault-agent|Dumping secret value to: /secrets/secrets/publisher-geneva-keyvault-speech-microsoft-com
|2024-09-09 18:30:21,069|INFO |1|129545540610944|keyvault-agent|Done!
```